### PR TITLE
Add the ability to get learner_id/student_id and learner_name from SCORM 1.2 or 2004

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -192,9 +192,11 @@ class ScormXBlock(XBlock):
             return {'value': self.success_status}
         elif name in ['cmi.core.score.raw', 'cmi.score.raw']:
             return {'value': self.lesson_score * 100}
-        elif name in ['cmi.learner_id', 'cmi.learner_name', 'cmi.core.student_id', 'cmi.core.student_name']:
+        elif name in ['cmi.learner_id', 'cmi.learner_name']:
             log.info('Get user data "{}"'.format(xb_user))
             return {'value': xb_user.opt_attrs.get('edx-platform.user_id', xb_user.full_name)}
+        elif name in ['cmi.core.student_id', 'cmi.core.student_name']:
+            return {'value': xb_user.full_name}
         else:
             return {'value': self.data_scorm.get(name, '')}
 

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -185,6 +185,8 @@ class ScormXBlock(XBlock):
     def scorm_get_value(self, data, suffix=''):
         user_service = self.runtime.service(self, 'user')
         xb_user = user_service.get_current_user()
+        anonymous_student_id = self.runtime.anonymous_student_id;
+        student_id = self.runtime.student_id;
         name = data.get('name')
         if name in ['cmi.core.lesson_status', 'cmi.completion_status']:
             return {'value': self.lesson_status}

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -192,7 +192,7 @@ class ScormXBlock(XBlock):
             return {'value': self.success_status}
         elif name in ['cmi.core.score.raw', 'cmi.score.raw']:
             return {'value': self.lesson_score * 100}
-        elif name in ['cmi.learner_id', 'cmi.core.student_id']:
+        elif name in ['cmi.learner_id', 'cmi.learner_name', 'cmi.core.student_id', 'cmi.core.student_name']:
             log.info('Get user data "{}"'.format(xb_user))
             return {'value': xb_user.opt_attrs.get('edx-platform.user_id', xb_user.full_name)}
         else:

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -185,8 +185,9 @@ class ScormXBlock(XBlock):
     def scorm_get_value(self, data, suffix=''):
         user_service = self.runtime.service(self, 'user')
         xb_user = user_service.get_current_user()
-        anonymous_student_id = self.runtime.anonymous_student_id;
-        student_id = self.runtime.student_id;
+        anonymous_student_id = self.runtime.anonymous_student_id
+        student_id = self.runtime.student_id
+        log.info('anonymous_student_id "{}", student_id "{}"'.format(anonymous_student_id,student_id))
         name = data.get('name')
         if name in ['cmi.core.lesson_status', 'cmi.completion_status']:
             return {'value': self.lesson_status}

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -185,21 +185,19 @@ class ScormXBlock(XBlock):
     def scorm_get_value(self, data, suffix=''):
         user_service = self.runtime.service(self, 'user')
         xb_user = user_service.get_current_user()
-        anonymous_student_id = self.runtime.anonymous_student_id
-        student_id = self.runtime.student_id
-        log.info('anonymous_student_id "{}", student_id "{}"'.format(anonymous_student_id,student_id))
         name = data.get('name')
+        log.info('Retrieve xb_user {}'.format(xb_user))
+        log.info('Retrieve anonymous student ID "{}"'.format(self.runtime.anonymous_student_id))
         if name in ['cmi.core.lesson_status', 'cmi.completion_status']:
             return {'value': self.lesson_status}
         elif name == 'cmi.success_status':
             return {'value': self.success_status}
         elif name in ['cmi.core.score.raw', 'cmi.score.raw']:
             return {'value': self.lesson_score * 100}
-        elif name in ['cmi.learner_id', 'cmi.learner_name']:
-            log.info('Get user data "{}"'.format(xb_user))
-            return {'value': xb_user.opt_attrs.get('edx-platform.user_id', xb_user.full_name)}
-        elif name in ['cmi.core.student_id', 'cmi.core.student_name']:
-            return {'value': xb_user.full_name}
+        elif name in ['cmi.learner_id', 'cmi.core.student_id']:
+            return {'value': xb_user.opt_attrs.get('edx-platform.user_id', xb_user.full_name) or self.runtime.anonymous_student_id}
+        elif name in ['cmi.learner_name', 'cmi.core.student_name']:
+            return {'value': xb_user.opt_attrs.get('edx-platform.username', xb_user.full_name)}
         else:
             return {'value': self.data_scorm.get(name, '')}
 

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -194,7 +194,7 @@ class ScormXBlock(XBlock):
             return {'value': self.lesson_score * 100}
         elif name in ['cmi.learner_id', 'cmi.core.student_id']:
             log.info('Get user data "{}"'.format(xb_user))
-            return {'value': xb_user.opt_attrs.get('edx-platform.user_id')}
+            return {'value': xb_user.opt_attrs.get('edx-platform.user_id', xb_user.full_name)}
         else:
             return {'value': self.data_scorm.get(name, '')}
 

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -26,11 +26,12 @@ from xblock.fragment import Fragment
 _ = lambda text: text
 
 log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
 
 SCORM_ROOT = os.path.join(settings.MEDIA_ROOT, 'scorm')
 SCORM_URL = os.path.join(settings.MEDIA_URL, 'scorm')
 
-
+@XBlock.wants('user')
 class ScormXBlock(XBlock):
 
     display_name = String(
@@ -182,6 +183,8 @@ class ScormXBlock(XBlock):
 
     @XBlock.json_handler
     def scorm_get_value(self, data, suffix=''):
+        user_service = self.runtime.service(self, 'user')
+        xb_user = user_service.get_current_user()
         name = data.get('name')
         if name in ['cmi.core.lesson_status', 'cmi.completion_status']:
             return {'value': self.lesson_status}
@@ -189,6 +192,9 @@ class ScormXBlock(XBlock):
             return {'value': self.success_status}
         elif name in ['cmi.core.score.raw', 'cmi.score.raw']:
             return {'value': self.lesson_score * 100}
+        elif name in ['cmi.learner_id', 'cmi.core.student_id']:
+            log.info('Get user data "{}"'.format(xb_user))
+            return {'value': xb_user.opt_attrs.get('edx-platform.user_id')}
         else:
             return {'value': self.data_scorm.get(name, '')}
 


### PR DESCRIPTION
As this official SCORM documentation explain it, in SCORM we can get some information about the current student : https://scorm.com/scorm-explained/technical-scorm/run-time/run-time-reference/

I added the ability to retrieve : 
* `cmi.core.student_id` (SCORM 1.2)
* `cmi.core. student_name `  (SCORM 1.2)
* `cmi.learner_id`  (SCORM 2004)
* `cmi.learner_name`  (SCORM 2004)