### PR TITLE
fix: Add ability to work with SCORM Cloud Dispatch service

### DIFF
--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -32,6 +32,7 @@ SCORM_URL = os.path.join(settings.MEDIA_URL, 'scorm')
 
 
 @XBlock.needs('i18n')
+@XBlock.wants('user')
 class ScormXBlock(XBlock):
 
     display_name = String(
@@ -196,8 +197,14 @@ class ScormXBlock(XBlock):
     @XBlock.json_handler
     def scorm_get_value(self, data, suffix=''):
         name = data.get('name')
+        user_service = self.runtime.service(self, 'user')
+        xb_user = user_service.get_current_user()
         if name in ['cmi.core.lesson_status', 'cmi.completion_status']:
             return {'value': self.lesson_status}
+        elif name == 'cmi.core.student_id':
+            return {'value': xb_user.opt_attrs.get('edx-platform.user_id')}
+        elif name == 'cmi.core.student_name':
+            return {'value': xb_user.opt_attrs.get('edx-platform.username')}
         elif name == 'cmi.success_status':
             return {'value': self.success_status}
         elif name in ['cmi.core.score.raw', 'cmi.score.raw']:

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -104,7 +104,7 @@ class ScormXBlock(XBlock):
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
         data = pkg_resources.resource_string(__name__, path)
-        return data.decode("utf8")
+        return data
 
     def student_view(self, context=None):
         context_html = self.get_context_student()

--- a/scormxblock/scormxblock.py
+++ b/scormxblock/scormxblock.py
@@ -199,6 +199,7 @@ class ScormXBlock(XBlock):
         name = data.get('name')
         user_service = self.runtime.service(self, 'user')
         xb_user = user_service.get_current_user()
+
         if name in ['cmi.core.lesson_status', 'cmi.completion_status']:
             return {'value': self.lesson_status}
         elif name == 'cmi.core.student_id':

--- a/scormxblock/tests.py
+++ b/scormxblock/tests.py
@@ -39,7 +39,7 @@ class ScormXBlockTests(unittest.TestCase):
         self.assertEqual(block.data_scorm, {})
         self.assertEqual(block.lesson_score, 0)
         self.assertEqual(block.weight, 1)
-        self.assertEqual(block.has_score, False)
+        self.assertEqual(block.has_score, True)
         self.assertEqual(block.icon_class, 'video')
         self.assertEqual(block.width, None)
         self.assertEqual(block.height, 450)
@@ -67,12 +67,11 @@ class ScormXBlockTests(unittest.TestCase):
     @mock.patch('scormxblock.scormxblock.shutil')
     @mock.patch('scormxblock.scormxblock.SCORM_ROOT')
     @mock.patch('scormxblock.scormxblock.os')
-    @mock.patch('scormxblock.scormxblock.zipfile')
     @mock.patch('scormxblock.scormxblock.File', return_value='call_file')
     @mock.patch('scormxblock.scormxblock.default_storage')
     @mock.patch('scormxblock.ScormXBlock._file_storage_path', return_value='file_storage_path')
     @mock.patch('scormxblock.ScormXBlock.get_sha1', return_value='sha1')
-    def test_save_scorm_zipfile(self, get_sha1, file_storage_path, default_storage, mock_file, zipfile,
+    def test_save_scorm_zipfile(self, get_sha1, file_storage_path, default_storage, mock_file,
                                 mock_os, SCORM_ROOT, shutil, set_fields_xblock):
         block = self.make_one()
         mock_file_object = mock.Mock()
@@ -107,9 +106,8 @@ class ScormXBlockTests(unittest.TestCase):
 
         self.assertEqual(block.scorm_file_meta, expected_scorm_file_meta)
 
-        zipfile.ZipFile.assert_called_once_with(mock_file_object, 'r')
         mock_os.path.join.assert_called_once_with(SCORM_ROOT, 'block_id')
-        mock_os.path.exists.assert_called_once_with('path_join')
+        mock_os.path.exists.assert_has_calls([mock.call(SCORM_ROOT), mock.call('path_join')])
         shutil.rmtree.assert_called_once_with('path_join')
         set_fields_xblock.assert_called_once_with('path_join')
 
@@ -128,8 +126,11 @@ class ScormXBlockTests(unittest.TestCase):
     @mock.patch('scormxblock.ScormXBlock._file_storage_path', return_value='file_storage_path')
     @mock.patch('scormxblock.scormxblock.default_storage')
     def test_student_view_data(self, default_storage, file_storage_path):
+        mock_file_object = mock.Mock(name='scorm_file_name', **{'open.return_value': '1223454'})
+
         block = self.make_one(
-            scorm_file_meta={'last_updated': '2018-05-01', 'size': 1234}
+            scorm_file_meta={'last_updated': '2018-05-01', 'size': 1234},
+            scorm_file='mock.Mock(return_value=mock_file_object)'
         )
         default_storage.configure_mock(url=mock.Mock(return_value='url_zip_file'))
 
@@ -142,7 +143,8 @@ class ScormXBlockTests(unittest.TestCase):
             {
                 'last_modified': '2018-05-01',
                 'scorm_data': 'url_zip_file',
-                'size': 1234
+                'size': 1234,
+                'index_page': None
             }
         )
 
@@ -170,7 +172,7 @@ class ScormXBlockTests(unittest.TestCase):
 
         self.assertEqual(
             response.json,
-            {'completion_status': 'completion_status', 'lesson_score': 0, 'result': 'success'}
+            {'completion_status': 'completion_status', 'lesson_score': '0.00', 'result': 'success'}
         )
 
     @mock.patch('scormxblock.ScormXBlock.get_completion_status', return_value='completion_status')
@@ -191,7 +193,7 @@ class ScormXBlockTests(unittest.TestCase):
 
         self.assertEqual(
             response.json,
-            {'completion_status': 'completion_status', 'lesson_score': 0.2, 'result': 'success'}
+            {'completion_status': 'completion_status', 'lesson_score': '0.20', 'result': 'success'}
         )
 
     @mock.patch('scormxblock.ScormXBlock.get_completion_status', return_value='completion_status')


### PR DESCRIPTION
Add ability to handle the next parameters:
 - `cmi.core.student_id`
 - `cmi.core.student_name`

Old tests are also fixed for python 3.8.

### Note

Henceforth this version of scorm_xblock requires XBlock==https://github.com/edx/XBlock/tree/xblock-1.2.4

Please pay attention when trying to apply these changes to the edx-platform